### PR TITLE
update docker version to 19.03.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM jenkins/jnlp-slave:${FROM_TAG}
 
 ARG GOSU_VERSION=1.11
 ARG DOCKER_CHANNEL=stable
-ARG DOCKER_VERSION=18.09.6
+ARG DOCKER_VERSION=19.03.2
 ARG TINY_VERSION=0.18.0
 
 ##########################################


### PR DESCRIPTION
- successfully tested the new docker version on my Jenkins Master/Slave network
- first tests show that the argument `--gpus` is working (nvidia-docker needs to be installed on the node)
- I suppose it is enough to install `nvidia-docker` on the node


Here the error I got with the previous version
```
java.io.IOException: Failed to run image '<my_image>'. Error: unknown flag: --gpus

See 'docker run --help'.
```